### PR TITLE
Add a TinyGo build to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,20 @@ jobs:
         with:
           name: go-ws-proxy-${{ matrix.os }}-${{ matrix.arch }}
           path: go-ws-proxy
+
+  tinygo-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tinygo/tinygo-action@v0.1.0
+
+      - run: |
+          go mod download
+          go test -v ./...
+          tinygo build -o go-ws-proxy main.go
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: go-ws-proxy-tinygo
+          path: go-ws-proxy


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kevmo314/go-ws-proxy/pull/1?shareId=68cada04-b503-4759-b54d-4cfd9ca79006).