### PR TITLE
fix: close websocket connection on exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer ws.Close()
+
 	go func() {
 		state, err := term.MakeRaw(int(os.Stdin.Fd()))
 		if err == nil {


### PR DESCRIPTION
Add defer ws.Close() to ensure the WebSocket connection is properly closed when the program exits.