### PR TITLE
fix: close websocket when stdin goroutine exits

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 		log.Fatal(err)
 	}
 	go func() {
+		defer ws.Close()
 		state, err := term.MakeRaw(int(os.Stdin.Fd()))
 		if err == nil {
 			defer term.Restore(int(os.Stdin.Fd()), state)


### PR DESCRIPTION
Close the WebSocket when stdin reaches EOF to signal the main goroutine to exit, preventing hangs.